### PR TITLE
Only deploy systemd file when solr v5 or later is used as it is not

### DIFF
--- a/tasks/install-pre5.yml
+++ b/tasks/install-pre5.yml
@@ -77,7 +77,10 @@
     group: root
     mode: 0755
   when: >
-    (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04') or
-    (ansible_distribution == 'Debian' and ansible_distribution_version|int >= 8) or
-    (ansible_distribution == 'CentOS' and ansible_distribution_major_version >= 7) or
-    (ansible_distribution == 'Fedora')
+    (solr_version.split('.')[0] | int >= 5) and
+    (
+        (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04') or
+        (ansible_distribution == 'Debian' and ansible_distribution_version|int >= 8) or
+        (ansible_distribution == 'CentOS' and ansible_distribution_major_version >= 7) or
+        (ansible_distribution == 'Fedora')
+    )


### PR DESCRIPTION
compatible with v4 or prior.

The template for the systemd script references a bin directory from the
solr_install_path that doesn’t exist in v3 or v4 packages, but is
present in v5 and v6. If the systemd file is put in place it overrides
the init.d script that is also put in place for solr v3 and the systemd
file fails to start the service, where when it does not exist systemd
reverts to using the init.d script via sysv.